### PR TITLE
fix(hooks): make PHP and Ruby path detection portable across platforms

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 
 <?php
 

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 branch_name = `git branch --show-current`.strip


### PR DESCRIPTION
Use '/usr/bin/env php' and '/usr/bin/env ruby' shebangs for cross-platform compatibility in:
- commit-msg
- pre-push.