### PR TITLE
fix(security): use separate JWT secrets for cookie auth and WebSocket…

### DIFF
--- a/packages/security/srcs/ws/createWsApp.ts
+++ b/packages/security/srcs/ws/createWsApp.ts
@@ -10,23 +10,40 @@ import {
 } from 'fastify-type-provider-zod'
 import fastifyJwt from '@fastify/jwt'
 
+interface JwtSecrets {
+	main: string
+	service: string
+}
+
 export function createWsApp(
 	appRoutes: any,
 	swager_data: any,
-	jwtSecret: string
+	jwtSecrets: JwtSecrets
 ): FastifyInstance {
-	if (!jwtSecret) {
-		throw new Error('bad JWT secret')
+	if (!jwtSecrets.main || !jwtSecrets.service) {
+		throw new Error('Missing JWT secrets')
 	}
 
 	const app = Fastify({ logger: true })
 		.withTypeProvider<ZodTypeProvider>()
 		.setValidatorCompiler(validatorCompiler)
 		.setSerializerCompiler(serializerCompiler)
+
 		.register(fastifyCookie)
+
 		.register(fastifyJwt, {
-			secret: jwtSecret
+			secret: jwtSecrets.main,
+			cookie: {
+				cookieName: 'auth_token',
+				signed: false
+			}
 		})
+
+		.register(fastifyJwt, {
+			secret: jwtSecrets.service,
+			namespace: 'ws'
+		})
+
 		.register(Swagger as any, swager_data)
 		.register(SwaggerUI as any, {
 			routePrefix: '/docs'

--- a/packages/security/srcs/ws/createWsToken.ts
+++ b/packages/security/srcs/ws/createWsToken.ts
@@ -30,7 +30,7 @@ export function createWsToken(
 		login: user.login
 	}
 
-	const wsToken = (fastify as any).jwt.sign(payload, {
+	const wsToken = (fastify as any).jwt.ws.sign(payload, {
 		expiresIn: `${WS_TOKEN_EXPIRES_SECONDS}s`
 	})
 

--- a/packages/security/srcs/ws/handleWsConnection.ts
+++ b/packages/security/srcs/ws/handleWsConnection.ts
@@ -16,7 +16,7 @@ export async function handleWsConnection(
 	const jwtI = (fastify as any).jwt
 
 	try {
-		return jwtI.verify(token)
+		return jwtI.ws.verify(token)
 	} catch (err) {
 		socket.send(
 			JSON.stringify({

--- a/services/pong-server/app/index.ts
+++ b/services/pong-server/app/index.ts
@@ -26,7 +26,10 @@ async function start(): Promise<void> {
 			},
 			transform: jsonSchemaTransform
 		},
-		process.env.JWT_SECRET_GAME as string
+		{
+			main: process.env.JWT_SECRET as string,
+			service: process.env.JWT_SECRET_GAME as string
+		}
 	)
 
 	try {

--- a/services/social/app/index.ts
+++ b/services/social/app/index.ts
@@ -23,7 +23,10 @@ export async function start(): Promise<void> {
 			},
 			transform: jsonSchemaTransform
 		},
-		process.env.JWT_SECRET_SOCIAL as string
+		{
+			main: process.env.JWT_SECRET as string,
+			service: process.env.JWT_SECRET_SOCIAL as string
+		}
 	)
 
 	try {


### PR DESCRIPTION
## Summary

Fix JWT authentication failure between services by separating cookie authentication and WebSocket token signing into two distinct JWT instances. 

## Problem

Previously, each service used a single JWT secret for both:
- Verifying the `auth_token` cookie (signed by Auth service)
- Signing/verifying WebSocket tokens

This caused authentication failures because Social and Pong services couldn't verify cookies signed by Auth service with `JWT_SECRET`. 

## Solution

```
┌─────────────────────────────────────────────────────────────┐
│  JWT_SECRET (shared)                                        │
│  • Signed by: Auth Service                                  │
│  • Verified by: ALL services (jwtAuthMiddleware)            │
│  • Cookie: auth_token                                       │
├─────────────────────────────────────────────────────────────┤
│  JWT_SECRET_SOCIAL / JWT_SECRET_GAME (per-service)          │
│  • Signed & verified by: respective service only            │
│  • Token: wsToken (WebSocket authentication)                │
└─────────────────────────────────────────────────────────────┘
```

## Changes

| File | Change |
|------|--------|
| `createWsApp.ts` | Accept `JwtSecrets` object, register two JWT instances |
| `createWsToken.ts` | Use `jwt.ws.sign()` for WebSocket tokens |
| `handleWsConnection.ts` | Use `jwt.ws.verify()` for WebSocket tokens |
| `services/social/index.ts` | Pass `{ main: JWT_SECRET, service: JWT_SECRET_SOCIAL }` |
| `services/pong-server/index.ts` | Pass `{ main: JWT_SECRET, service: JWT_SECRET_GAME }` |

## Testing

- [x] Login via Auth service
- [x] Create WebSocket token via `/api/social/create-token`
- [x] Connect to WebSocket with token