### PR TITLE
fix: join/create game error messages

### DIFF
--- a/services/frontend/app/src/events/home/createGameHandler.ts
+++ b/services/frontend/app/src/events/home/createGameHandler.ts
@@ -1,13 +1,13 @@
 import { gameStore } from '../../usecases/gameStore.js'
-import { notyfGlobal as notyf } from '../../utils/notyf.js'
 import { createGameApi } from '../../api/game/createGame.js'
 import { joinGameApi } from '../../api/game/joinGame.js'
+import { sendGameError } from './errorMapUtils.js'
 
 export async function handleCreateGame() {
 	const { data, error, status } = await createGameApi()
 
 	if (error) {
-		notyf.error(error)
+		sendGameError(error, status)
 		return
 	}
 
@@ -17,12 +17,7 @@ export async function handleCreateGame() {
 	gameStore.gameCode = code
 	if (joinPayload.error) {
 		gameStore.clear()
-
-		if (status === 400) {
-			notyf.error('Invalid game code!')
-		} else {
-			notyf.error(joinPayload.error)
-		}
+		sendGameError(joinPayload.error, status)
 		return
 	}
 

--- a/services/frontend/app/src/events/home/errorMapUtils.ts
+++ b/services/frontend/app/src/events/home/errorMapUtils.ts
@@ -1,0 +1,18 @@
+import { notyfGlobal as notyf } from '../../utils/notyf.js'
+
+const remapError: Record<string, string> = {
+	'player is already in a game': 'You are already in a game!',
+	'a player is already in a game': 'You are already in a game!',
+	'player not allowed in this game': 'You are not authorized to join this game',
+	'unknow game code': 'Invalid game code!'
+}
+
+export function sendGameError(error: string, status: number) {
+	if (status === 400) {
+		notyf.error('Invalid game code!')
+	} else {
+		console.log(error)
+		const errorMessage = remapError[error] || error
+		notyf.error(errorMessage)
+	}
+}

--- a/services/frontend/app/src/events/home/joinLobbyHandler.ts
+++ b/services/frontend/app/src/events/home/joinLobbyHandler.ts
@@ -1,6 +1,6 @@
 import { joinGameApi } from '../../api/game/joinGame.js'
 import { gameStore } from '../../usecases/gameStore.js'
-import { notyfGlobal as notyf } from '../../utils/notyf.js'
+import { sendGameError } from './errorMapUtils.js'
 
 export async function handleJoinLobby(e: Event) {
 	e.preventDefault()
@@ -11,13 +11,8 @@ export async function handleJoinLobby(e: Event) {
 
 	gameStore.gameCode = code
 	if (error) {
+		sendGameError(error, status)
 		gameStore.clear()
-
-		if (status === 400) {
-			notyf.error('Invalid game code!')
-		} else {
-			notyf.error(error)
-		}
 		return
 	}
 

--- a/services/game/app/usecases/managers/gameManager/errors/errorMap.ts
+++ b/services/game/app/usecases/managers/gameManager/errors/errorMap.ts
@@ -3,6 +3,5 @@ export const gameErrorMap: Record<string, number> = {
 	'player is already in a game': 409,
 	'unknown game code': 404,
 	'player not allowed in this game': 403,
-	'player not in game': 400,
 	'game not found': 404
 }

--- a/services/game/app/usecases/managers/gameManager/gameManager.md
+++ b/services/game/app/usecases/managers/gameManager/gameManager.md
@@ -185,13 +185,6 @@ wins by forfeit (if applicable).
 > No validation is performed on `pID` (e.g., checking if they exist in
 > the database). This is the caller's responsibility.
 
-**Errors:**
-
-| Error                  | Cause                                           |
-| ---------------------- | ----------------------------------------------- |
-| `'player not in game'` | Player has no active game in `playerToGame`     |
-| `'game not found'`     | Game code from mapping doesn't exist in `games` |
-
 ---
 
 ## Error Summary


### PR DESCRIPTION
This pull request refactors how game-related error messages are handled in the frontend by centralizing error mapping and notification logic. Instead of directly displaying raw error messages, the code now uses a utility function to map backend errors to user-friendly notifications. This improves code maintainability and ensures consistent error handling across different parts of the application.

**Frontend Error Handling Refactor:**

* Introduced a new utility function `sendGameError` in `errorMapUtils.ts` to handle error mapping and user notifications, replacing direct calls to `notyf.error` in both `createGameHandler.ts` and `joinLobbyHandler.ts`. [[1]](diffhunk://#diff-ee3ad60e1a29ebf35d48975029db4724fb2e6c95da6d79fb55635f36e2aea32cR1-R18) [[2]](diffhunk://#diff-509c923e8e193b1444c4db582c1fe17576d7358309f36b595be838410a1bc565L2-R10) [[3]](diffhunk://#diff-509c923e8e193b1444c4db582c1fe17576d7358309f36b595be838410a1bc565L20-R20) [[4]](diffhunk://#diff-9c44ea44bf3c3e2267f1390c26395fe4ff21fdece1b6e26dee6fd7f8c7ed0572L3-R3) [[5]](diffhunk://#diff-9c44ea44bf3c3e2267f1390c26395fe4ff21fdece1b6e26dee6fd7f8c7ed0572R14-L20)
* Centralized error message remapping for common backend errors, providing more user-friendly feedback in the UI.

**Backend Error Mapping Cleanup:**

* Removed the `'player not in game': 400` mapping from `gameErrorMap` in `errorMap.ts` to reflect updated error handling logic.
* Updated documentation in `gameManager.md` to remove references to the `'player not in game'` error.