### PR TITLE
fix: delete tournament when he is empty

### DIFF
--- a/services/game/app/usecases/managers/tournamentManager/quitTournament.ts
+++ b/services/game/app/usecases/managers/tournamentManager/quitTournament.ts
@@ -24,4 +24,7 @@ export function quitTournament(request: FastifyRequest): void {
 	}
 	tournament.participants.splice(participantIndex, 1)
 	usersInTournaments.delete(userId)
+	if (tournament.participants.length === 0) {
+		tournaments.delete(tournamentCode.code)
+	}
 }


### PR DESCRIPTION
This pull request introduces a small but important change to the tournament management logic. Now, when the last participant quits a tournament, the tournament is automatically deleted to keep the system clean and prevent empty tournaments from lingering.

- Tournament cleanup:
  * In `quitTournament.ts`, the code now checks if a tournament has no remaining participants after someone quits, and if so, deletes the tournament from the active list.