### PR TITLE
Refactor/rename runmigrations functions

### DIFF
--- a/services/2fa/app/database/connection.ts
+++ b/services/2fa/app/database/connection.ts
@@ -15,7 +15,7 @@ export function getDb(): Database {
 	return db
 }
 
-export function initDBs() {
+export function initDB() {
 	const db = getDb()
 
 	db.pragma('journal_mode = WAL')

--- a/services/2fa/app/index.ts
+++ b/services/2fa/app/index.ts
@@ -1,5 +1,5 @@
 import Fastify, { FastifyInstance } from 'fastify'
-import { initDBs } from './database/connection.js'
+import { initDB } from './database/connection.js'
 import {
 	ZodTypeProvider,
 	validatorCompiler,
@@ -30,7 +30,7 @@ app.register(fastifyJwt, {
 app.setValidatorCompiler(validatorCompiler)
 app.setSerializerCompiler(serializerCompiler)
 
-initDBs()
+initDB()
 
 setupErrorHandler(app)
 setupFastifyMonitoringHooks(app)

--- a/services/auth/app/database/connection.ts
+++ b/services/auth/app/database/connection.ts
@@ -16,7 +16,7 @@ export function getDb(): Database {
 	return db
 }
 
-export function initDBs() {
+export function initDB() {
 	const db = getDb()
 
 	db.pragma('journal_mode = WAL')

--- a/services/auth/app/index.ts
+++ b/services/auth/app/index.ts
@@ -1,5 +1,5 @@
 import Fastify from 'fastify'
-import { initDBs } from './database/connection.js'
+import { initDB } from './database/connection.js'
 import {
 	ZodTypeProvider,
 	validatorCompiler,
@@ -41,7 +41,7 @@ setupFastifyMonitoringHooks(app)
 
 async function runServer() {
 	console.log('Starting Auth service...')
-	initDBs()
+	initDB()
 	console.log('Admin user ensured')
 
 	await app.register(metricPlugin.default, { endpoint: '/metrics' })

--- a/services/game/app/database/connection.ts
+++ b/services/game/app/database/connection.ts
@@ -16,7 +16,7 @@ export function getDb(): Database {
 	return db
 }
 
-export function initDBs() {
+export function initDB() {
 	const db = getDb()
 
 	db.pragma('journal_mode = WAL')

--- a/services/game/app/index.ts
+++ b/services/game/app/index.ts
@@ -3,13 +3,13 @@ import { createWsApp } from '@ft_transcendence/security'
 import { registerRoutes } from './routes/registerRoutes.js'
 import { env } from './env/checkEnv.js'
 import { setupFastifyMonitoringHooks } from '@ft_transcendence/monitoring'
-import { initDBs } from './database/connection.js'
+import { initDB } from './database/connection.js'
 import { gameRoutes } from './routes/gameRoutes.js'
 import { initializeTournamentId } from './usecases/managers/tournamentManager/createTournament.js'
 import metricPlugin from 'fastify-metrics'
 
 // Run migrations first, then initialize tournament ID
-initDBs()
+initDB()
 initializeTournamentId()
 
 async function start(): Promise<void> {


### PR DESCRIPTION
This pull request standardizes the database initialization process across the `2fa`, `auth`, and `game` services by renaming the `runMigrations` function to `initDB`. All usages and imports of this function are updated accordingly, ensuring a consistent and clear approach to database setup in each service.

**Database initialization function rename and usage update:**

* Renamed the `runMigrations` function to `initDB` in `services/2fa/app/database/connection.ts`, `services/auth/app/database/connection.ts`, and `services/game/app/database/connection.ts`. [[1]](diffhunk://#diff-c0ffc0152c1461ee93846a1c2dc9aab20528e28b2ee1541b2b4cdfbe47c0f938L18-R18) [[2]](diffhunk://#diff-b358ef38e534b2fa091e0b8c974904306b7293656578dfbf79b9f63bfe6a5e44L19-R19) [[3]](diffhunk://#diff-daa6cc8f72dbe9ae9c68026241be56910e61a0e066216fcb97e8a9d60fe65a5eL19-R19)
* Updated all imports and calls from `runMigrations` to `initDB` in the main entry files for each service: `services/2fa/app/index.ts`, `services/auth/app/index.ts`, and `services/game/app/index.ts`. [[1]](diffhunk://#diff-4ea409f4fa6d157669ce167afad06d4aaf5eda5976a9143015bea17dc9ca052eL2-R2) [[2]](diffhunk://#diff-4ea409f4fa6d157669ce167afad06d4aaf5eda5976a9143015bea17dc9ca052eL33-R33) [[3]](diffhunk://#diff-c076e2cb34073711185986fff46a7816bccc053b024a083297dd0ee88aba0adeL2-R2) [[4]](diffhunk://#diff-c076e2cb34073711185986fff46a7816bccc053b024a083297dd0ee88aba0adeL44-R44) [[5]](diffhunk://#diff-f617a7368019697d2fe56cbaa5311dfe40c908a7722b56bf089ab6790e5421a4L6-R12)

This change improves code clarity and ensures that the initialization process is consistently named and invoked across all services.