### PR TITLE
fix: change entrypoint.dev for entrypoint

### DIFF
--- a/services/nginx/Dockerfile.dev
+++ b/services/nginx/Dockerfile.dev
@@ -7,9 +7,9 @@ RUN mkdir -p /usr/share/nginx/html/avatars
 
 COPY conf/default.dev.conf /etc/nginx/http.d/default.conf.template
 COPY avatars/img_default.png /usr/share/nginx/html/avatars/img_default.png
-COPY entrypoint.dev.sh /usr/local/bin/entrypoint.dev.sh
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
-RUN chmod +x /usr/local/bin/entrypoint.dev.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 RUN chown -R 1000:1000 /usr/share/nginx/html/avatars \
     && chmod -R 755 /usr/share/nginx/html/avatars


### PR DESCRIPTION
This pull request makes a minor update to the Nginx development Dockerfile by switching the entrypoint script from `entrypoint.dev.sh` to `entrypoint.sh` and ensuring the correct script is copied and made executable. No other significant changes are included.