### PR TITLE
feat: delete tournament from map after 1 minute

### DIFF
--- a/services/game/app/usecases/managers/tournamentManager/onTournamentMatchEnd.ts
+++ b/services/game/app/usecases/managers/tournamentManager/onTournamentMatchEnd.ts
@@ -43,6 +43,13 @@ export function onTournamentMatchEnd(
 		})
 
 		updateGameMetrics()
+		setTimeout(
+			() => {
+				tournaments.delete(tournamentCode)
+				console.log(`Tournament ${tournamentCode} data cleaned up from memory`)
+			},
+			1 * 60 * 1000
+		)
 		return
 	}
 

--- a/services/game/app/usecases/managers/tournamentManager/startTournament.ts
+++ b/services/game/app/usecases/managers/tournamentManager/startTournament.ts
@@ -9,7 +9,7 @@ export function startTournament(code: string, tournament: Tournament) {
 
 	setTimeout(() => {
 		startFirstRound(code, tournament)
-	}, 10000)
+	}, 5000)
 
 	updateGameMetrics()
 }


### PR DESCRIPTION
This pull request introduces improvements to the tournament lifecycle management by optimizing the timing of tournament round starts and ensuring timely cleanup of tournament data from memory. The changes help reduce waiting times for players and improve memory usage after tournaments conclude.

Tournament round timing:

* Reduced the delay before starting the first round of a tournament from 10 seconds to 5 seconds in `startTournament`, allowing games to begin more quickly. (`services/game/app/usecases/managers/tournamentManager/startTournament.ts`)

Tournament data cleanup:

* Added a scheduled cleanup to remove tournament data from memory one minute after a tournament match ends, preventing memory leaks and improving resource usage. (`services/game/app/usecases/managers/tournamentManager/onTournamentMatchEnd.ts`)