### PR TITLE
feature: delete tournament from map after 1 minute

### DIFF
--- a/services/game/app/usecases/managers/tournamentManager/onTournamentMatchEnd.ts
+++ b/services/game/app/usecases/managers/tournamentManager/onTournamentMatchEnd.ts
@@ -43,6 +43,13 @@ export function onTournamentMatchEnd(
 		})
 
 		updateGameMetrics()
+		setTimeout(
+			() => {
+				tournaments.delete(tournamentCode)
+				console.log(`Tournament ${tournamentCode} data cleaned up from memory`)
+			},
+			1 * 60 * 1000
+		)
 		return
 	}
 

--- a/services/game/app/usecases/managers/tournamentManager/startTournament.ts
+++ b/services/game/app/usecases/managers/tournamentManager/startTournament.ts
@@ -9,7 +9,7 @@ export function startTournament(code: string, tournament: Tournament) {
 
 	setTimeout(() => {
 		startFirstRound(code, tournament)
-	}, 10000)
+	}, 5000)
 
 	updateGameMetrics()
 }


### PR DESCRIPTION
This pull request introduces improvements to the tournament management logic, focusing on resource cleanup and tournament start timing. The most important changes are grouped below:

Tournament lifecycle management:

* Added a delayed cleanup step to remove tournament data from memory one minute after a tournament match ends, helping prevent memory leaks and ensuring resources are freed in a timely manner.

Tournament start timing:

* Reduced the delay before starting the first round of a tournament from 10 seconds to 5 seconds, making tournament startup more responsive.