### PR TITLE
fix: change password regex for accepting all characteres excepte <>$

### DIFF
--- a/packages/common/srcs/DTO/authSchema.ts
+++ b/packages/common/srcs/DTO/authSchema.ts
@@ -1,8 +1,7 @@
 import { z } from 'zod'
 import { RegisterLoginSchema } from './usersSchema.js'
 
-const PASSWORD_REGEX =
-	/^(?=.*[A-Z])(?=.*\d)(?=.*[a-z])[A-Za-z\d!@#$%^&*()_+=[\]{};':"\\|,./?-]{8,128}$/
+const PASSWORD_REGEX = /^(?=.*[A-Z])(?=.*\d)(?=.*[a-z])[^<>$]{8,128}$/
 
 export const PasswordSchema = z
 	.string()
@@ -10,7 +9,7 @@ export const PasswordSchema = z
 	.max(128, 'Password must be at most 128 characters long')
 	.regex(
 		PASSWORD_REGEX,
-		'Password must include at least one capital letter, one lower case letter and one number'
+		'Password must include at least one capital letter, one lower case letter and one number and exclude <>$ characters'
 	)
 
 export const RegisterSchema = z


### PR DESCRIPTION
This pull request updates the password validation logic in the `authSchema.ts` file to strengthen security requirements and clarify error messaging.

Password validation changes:

* Updated the `PASSWORD_REGEX` to disallow the characters `<`, `>`, and ` in passwords, while still requiring at least one uppercase letter, one lowercase letter, one number, and a length between 8 and 128 characters.
* Improved the password validation error message to specify that passwords must exclude `<`, `>`, and ` characters.