### PR TITLE
chore: remove useless Dockerfile for prometheus and debug print in entrypoint

### DIFF
--- a/services/monitoring/alertmanager/entrypoint.sh
+++ b/services/monitoring/alertmanager/entrypoint.sh
@@ -1,6 +1,3 @@
 #!/bin/sh
-echo "Template exists?"; ls -l /etc/alertmanager/
-echo "Discord Webhook URL: $DISCORD_WEBHOOK_URL"
 envsubst < /etc/alertmanager/alertmanager.yml.template > /etc/alertmanager/alertmanager.yml
-cat /etc/alertmanager/alertmanager.yml
 exec /bin/alertmanager --config.file=/etc/alertmanager/alertmanager.yml "$@"

--- a/services/monitoring/prometheus/Dockerfile
+++ b/services/monitoring/prometheus/Dockerfile
@@ -1,8 +1,0 @@
-FROM prom/prometheus:v3.7.2
-
-COPY prometheus.yaml /etc/prometheus/prometheus.yml
-COPY rules.yaml /etc/prometheus/rules.yml
-
-CMD ["--config.file=/etc/prometheus/prometheus.yml", \
-     "--web.external-url=http://localhost:8080/prometheus", \
-     "--web.route-prefix=/prometheus"]


### PR DESCRIPTION
This pull request removes debugging output from the Alertmanager entrypoint script and deletes the Prometheus Dockerfile, likely as part of a cleanup or migration effort.

Cleanup and removal of debugging and configuration files:

* Removed all debugging `echo` and `cat` statements from `entrypoint.sh` in the Alertmanager service to streamline the startup process.
* Deleted the Prometheus `Dockerfile`, including its configuration and command setup, from the monitoring services.