### PR TITLE
chore: remove print of conf and add a message when nginx start to launch

### DIFF
--- a/services/nginx/entrypoint.sh
+++ b/services/nginx/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 envsubst '$HOSTNAME $PORT $USERS_SERVICE_URL $TWOFA_SERVICE_URL $AUTH_SERVICE_URL $SOCIAL_SERVICE_URL $GAME_SERVICE_URL $SUBNET_DOCKER_MONITORING' < /etc/nginx/http.d/default.conf.template > /etc/nginx/http.d/default.conf
-cat /etc/nginx/http.d/default.conf
-exec nginx -g 'daemon off;' 
+echo "Nginx launched"
+exec nginx -g 'daemon off;'


### PR DESCRIPTION
This pull request makes a minor change to the `services/nginx/entrypoint.sh` script. Instead of outputting the contents of the generated Nginx config file, it now prints a simple "Nginx launched" message before starting the Nginx server.