### PR TITLE
fix: add type zod for promise void

### DIFF
--- a/packages/common/srcs/DTO/2faSchema.ts
+++ b/packages/common/srcs/DTO/2faSchema.ts
@@ -102,6 +102,15 @@ export const Verify2FALoginResponseSchema = z
 	})
 	.strict()
 
+export const internalGoogleUserStatusResponseSchema = z
+	.object({
+		is_google_user: z.boolean()
+	})
+	.strict()
+	.meta({
+		description: 'Indicates if a Google user exists in the system'
+	})
+
 export type Verify2FADTO = z.infer<typeof verify2FASchema>
 export type Setup2FADTO = z.infer<typeof setup2FASchema>
 export type Disable2FADTO = z.infer<typeof disable2FASchema>
@@ -115,4 +124,7 @@ export type Call2FAResponseDTO = z.infer<typeof Call2FAResponseSchema>
 export type Enable2FAResponseDTO = z.infer<typeof Enable2FAResponseSchema>
 export type Verify2FALoginResponseDTO = z.infer<
 	typeof Verify2FALoginResponseSchema
+>
+export type InternalGoogleUserStatusResponseDTO = z.infer<
+	typeof internalGoogleUserStatusResponseSchema
 >

--- a/services/auth/app/controllers/2faController.ts
+++ b/services/auth/app/controllers/2faController.ts
@@ -5,7 +5,8 @@ import {
 	Enable2FAResponseDTO,
 	Status2FAResponseDTO,
 	twofaCodeSchema,
-	Verify2FALoginResponseDTO
+	Verify2FALoginResponseDTO,
+	InternalGoogleUserStatusResponseDTO
 } from '@ft_transcendence/common'
 import {
 	enable2FA,
@@ -142,7 +143,7 @@ export async function internalStatus2faController(
 export async function internalGoogleUserStatusController(
 	req: FastifyRequest,
 	reply: FastifyReply
-): Promise<{ is_google_user: boolean }> {
+): Promise<InternalGoogleUserStatusResponseDTO> {
 	const { id } = req.params as { id: string }
 	const userId = Number(id)
 	if (isNaN(userId)) throw createHttpError.BadRequest('Invalid user id')

--- a/services/auth/app/controllers/authController.ts
+++ b/services/auth/app/controllers/authController.ts
@@ -108,9 +108,7 @@ export async function logoutController(
 			},
 			signal: AbortSignal.timeout(3000)
 		})
-	} catch (e) {
-		console.error(`[Logout] Failed to cleanup user ${userId}:`, e)
-	}
+	} catch (e) {}
 
 	reply.clearCookie('auth_token', { path: '/' })
 	reply.clearCookie('twofa_token', { path: '/' })

--- a/services/auth/app/routes/2faRoutes.ts
+++ b/services/auth/app/routes/2faRoutes.ts
@@ -14,9 +14,11 @@ import {
 	status2FAResponseSchema,
 	twofaCodeSchema,
 	Verify2FALoginResponseSchema,
-	HttpErrorSchema
+	HttpErrorSchema,
+	internalGoogleUserStatusResponseSchema
 } from '@ft_transcendence/common'
 import { apiKeyMiddleware, jwtAuthMiddleware } from '@ft_transcendence/security'
+import { z } from 'zod'
 
 export async function twoFARoutes(app: FastifyInstance) {
 	app.post(
@@ -50,7 +52,7 @@ export async function twoFARoutes(app: FastifyInstance) {
 				tags: ['2fa'],
 				body: twofaCodeSchema,
 				response: {
-					200: { type: 'object' },
+					200: z.any().meta({ description: '2FA setup verified successfully' }),
 					401: HttpErrorSchema.meta({
 						description: 'Invalid 2FA code'
 					}),
@@ -93,7 +95,7 @@ export async function twoFARoutes(app: FastifyInstance) {
 				description: 'Disables 2FA for the authenticated user.',
 				tags: ['2fa'],
 				response: {
-					200: { type: 'object' },
+					200: z.any().meta({ description: '2FA disabled successfully' }),
 					401: HttpErrorSchema.meta({
 						description: 'Not authenticated'
 					}),
@@ -156,7 +158,7 @@ export async function twoFARoutes(app: FastifyInstance) {
 				tags: ['oauth', 'internal'],
 				params: IdParamSchema,
 				response: {
-					200: { type: 'object' },
+					200: internalGoogleUserStatusResponseSchema,
 					401: HttpErrorSchema.meta({
 						description: 'Invalid API key'
 					}),

--- a/services/auth/app/routes/authRoutes.ts
+++ b/services/auth/app/routes/authRoutes.ts
@@ -17,6 +17,7 @@ import {
 	HttpErrorSchema
 } from '@ft_transcendence/common'
 import { jwtAuthMiddleware } from '@ft_transcendence/security'
+import { z } from 'zod'
 
 export async function authRoutes(app: FastifyInstance) {
 	app.post(
@@ -92,7 +93,7 @@ export async function authRoutes(app: FastifyInstance) {
 				description: 'Validates if the current user has admin privileges.',
 				tags: ['auth', 'admin'],
 				response: {
-					200: { type: 'object' },
+					200: z.any().meta({ description: 'User is an admin' }),
 					401: HttpErrorSchema.meta({
 						description: 'Not authenticated'
 					}),
@@ -113,7 +114,7 @@ export async function authRoutes(app: FastifyInstance) {
 				description: 'Logs out the current user and invalidates the session.',
 				tags: ['auth'],
 				response: {
-					200: { type: 'object' }
+					200: z.any().meta({ description: 'Logout successful' })
 				}
 			},
 			preHandler: jwtAuthMiddleware

--- a/services/auth/app/routes/userRoutes.ts
+++ b/services/auth/app/routes/userRoutes.ts
@@ -14,6 +14,7 @@ import {
 	PasswordBodySchema,
 	HttpErrorSchema
 } from '@ft_transcendence/common'
+import { z } from 'zod'
 
 export async function userRoutes(app: FastifyInstance) {
 	app.patch(
@@ -24,7 +25,7 @@ export async function userRoutes(app: FastifyInstance) {
 				tags: ['user'],
 				body: ChangeMyPasswordSchema,
 				response: {
-					200: { type: 'object' },
+					200: z.any().meta({ description: 'Password changed successfully' }),
 					400: HttpErrorSchema.meta({
 						description: 'Invalid request body'
 					}),
@@ -47,7 +48,7 @@ export async function userRoutes(app: FastifyInstance) {
 				tags: ['user', 'auth'],
 				body: PasswordBodySchema,
 				response: {
-					200: { type: 'object' },
+					200: z.any().meta({ description: 'Password verified successfully' }),
 					401: HttpErrorSchema.meta({
 						description: 'Not authenticated or wrong password'
 					})


### PR DESCRIPTION
This pull request introduces improvements to the response schema definitions and OpenAPI documentation for several authentication and user-related endpoints. The main changes include defining a new schema for checking if a Google user exists, updating route response schemas to use more descriptive metadata, and ensuring type safety throughout the codebase.

**Schema and Type Improvements:**

* Added a new `internalGoogleUserStatusResponseSchema` in `2faSchema.ts` to standardize the response for checking if a Google user exists in the system, along with its corresponding TypeScript type. [[1]](diffhunk://#diff-34c40a580499881074987c09f9f2c412960c7683678b3220c12142cf2c8f0427R105-R113) [[2]](diffhunk://#diff-34c40a580499881074987c09f9f2c412960c7683678b3220c12142cf2c8f0427R128-R130)

**Controller and Route Enhancements:**

* Updated the `internalGoogleUserStatusController` to return the new strongly-typed response (`InternalGoogleUserStatusResponseDTO`).
* Modified the OpenAPI response schemas for various endpoints (2FA, auth, and user routes) to use `z.any().meta({ description: ... })` instead of generic `{ type: 'object' }`, providing clearer API documentation and intent. [[1]](diffhunk://#diff-f4da840eacd67ddce6183bfc4c415a70f53bc7f2ca107fff31bfa379cf2d026cL53-R55) [[2]](diffhunk://#diff-f4da840eacd67ddce6183bfc4c415a70f53bc7f2ca107fff31bfa379cf2d026cL96-R98) [[3]](diffhunk://#diff-f4da840eacd67ddce6183bfc4c415a70f53bc7f2ca107fff31bfa379cf2d026cL159-R161) [[4]](diffhunk://#diff-3edc7293d4a0678890cd293dcab4e52c4d2c591ba8421875159094045e9276c7L95-R96) [[5]](diffhunk://#diff-3edc7293d4a0678890cd293dcab4e52c4d2c591ba8421875159094045e9276c7L116-R117) [[6]](diffhunk://#diff-e4d8cccfb78985ce744dd66aa350eaabcaad651d7a36bbd09b18cc3175e77bf5L27-R28) [[7]](diffhunk://#diff-e4d8cccfb78985ce744dd66aa350eaabcaad651d7a36bbd09b18cc3175e77bf5L50-R51)

**Code Quality and Error Handling:**

* Cleaned up error handling in `logoutController` by removing unnecessary logging on failure to clean up user sessions.

**Dependency Management:**

* Added missing imports for `z` from `zod` in several route files to support the new schema definitions. [[1]](diffhunk://#diff-f4da840eacd67ddce6183bfc4c415a70f53bc7f2ca107fff31bfa379cf2d026cL17-R21) [[2]](diffhunk://#diff-3edc7293d4a0678890cd293dcab4e52c4d2c591ba8421875159094045e9276c7R20) [[3]](diffhunk://#diff-e4d8cccfb78985ce744dd66aa350eaabcaad651d7a36bbd09b18cc3175e77bf5R17)