### PR TITLE
chore: rename JWT_SECRET wit add _AUTH

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,12 +83,6 @@ SOCIAL_DB_PATH=/data/db-social.sqlite
 PASSWORD_ADMIN=Change-me-admin-password1
 
 # ========================================
-# Monitoring & Admin
-# ========================================
-# Admin token for accessing monitoring endpoints and administrative functions
-ADMIN_TOKEN=change-me-admin-token
-
-# ========================================
 # Frontend Configuration
 # ========================================
 # Base URL where the frontend is accessible (used for OAuth redirects, CORS, etc.)
@@ -117,7 +111,7 @@ DTO_OPENAPI_FILE=/app/packages/common/openapiDTO.json
 # ========================================
 # Secret key for signing and verifying JWT tokens (auth service)
 # Generate a strong random string: openssl rand -base64 32
-JWT_SECRET=change-me-jwt-secret
+JWT_SECRET_AUTH=change-me-jwt-secret
 # Separate JWT secret for social service token signing
 JWT_SECRET_SOCIAL=change-me-jwt-secret-social
 # Separate JWT secret for game service token signing

--- a/.github/workflows/make-unit-test.yml
+++ b/.github/workflows/make-unit-test.yml
@@ -65,9 +65,6 @@ jobs:
           # Admin credentials
           PASSWORD_ADMIN=Admin1234
 
-          # Monitoring / other
-          ADMIN_TOKEN=change-me
-
           # Frontend
           FRONTEND_BASE_URL=http://localhost:8080
 
@@ -81,7 +78,7 @@ jobs:
           DTO_OPENAPI_FILE=/app/packages/common/openapiDTO.json
 
           # JWT
-          JWT_SECRET=change-me
+          JWT_SECRET_AUTH=change-me
           JWT_SECRET_SOCIAL=change-me
           JWT_SECRET_GAME=change-me
           WS_TOKEN_EXPIRES_SECONDS=30

--- a/services/2fa/app/env/checkEnv.ts
+++ b/services/2fa/app/env/checkEnv.ts
@@ -5,7 +5,7 @@ const envSchema = z
 	.object({
 		DTO_OPENAPI_FILE: z.string().min(1),
 		PORT: z.coerce.number().min(1).max(65535),
-		JWT_SECRET: z.string().min(1),
+		JWT_SECRET_AUTH: z.string().min(1),
 		TWOFA_DB_PATH: z.string().min(1),
 		TOTP_ENC_KEY: z
 			.string()
@@ -18,7 +18,7 @@ const envSchema = z
 	})
 	.transform((env) => ({
 		PORT: env.PORT,
-		JWT_SECRET: env.JWT_SECRET,
+		JWT_SECRET_AUTH: env.JWT_SECRET_AUTH,
 		TWOFA_DB_PATH: env.TWOFA_DB_PATH,
 		TOTP_ENC_KEY: env.TOTP_ENC_KEY,
 		openAPISchema: loadOpenAPISchema(env.DTO_OPENAPI_FILE),

--- a/services/2fa/app/index.ts
+++ b/services/2fa/app/index.ts
@@ -22,7 +22,7 @@ export const app: FastifyInstance = Fastify({
 
 app.register(fastifyCookie)
 app.register(fastifyJwt, {
-	secret: env.JWT_SECRET,
+	secret: env.JWT_SECRET_AUTH,
 	cookie: {
 		cookieName: 'auth_token',
 		signed: false

--- a/services/auth/app/env/checkEnv.ts
+++ b/services/auth/app/env/checkEnv.ts
@@ -9,7 +9,7 @@ const envSchema = z
 	.object({
 		DTO_OPENAPI_FILE: z.string().min(1),
 		PORT: z.coerce.number().min(1).max(65535),
-		JWT_SECRET: z.string().min(1),
+		JWT_SECRET_AUTH: z.string().min(1),
 		AUTH_DB_PATH: z.string().min(1),
 		PASSWORD_ADMIN: PasswordSchema,
 		GOOGLE_CLIENT_ID: z.string().min(1),
@@ -22,7 +22,7 @@ const envSchema = z
 	})
 	.transform((env) => ({
 		PORT: env.PORT,
-		JWT_SECRET: env.JWT_SECRET,
+		JWT_SECRET_AUTH: env.JWT_SECRET_AUTH,
 		AUTH_DB_PATH: env.AUTH_DB_PATH,
 		LOGIN_ADMIN: 'transcendence',
 		PASSWORD_ADMIN: env.PASSWORD_ADMIN,

--- a/services/auth/app/index.ts
+++ b/services/auth/app/index.ts
@@ -24,7 +24,7 @@ const app = Fastify({
 
 app.register(cookie)
 app.register(fastifyJwt, {
-	secret: env.JWT_SECRET,
+	secret: env.JWT_SECRET_AUTH,
 	cookie: {
 		cookieName: 'auth_token',
 		signed: false

--- a/services/auth/app/usecases/authUsecases.test.ts
+++ b/services/auth/app/usecases/authUsecases.test.ts
@@ -11,7 +11,7 @@
 import { describe, test, expect, jest, beforeAll } from '@jest/globals'
 import jwt from 'jsonwebtoken'
 
-const JWT_SECRET = 'test-secret-for-admin-validation'
+const JWT_SECRET_AUTH = 'test-secret-for-admin-validation'
 
 // Mock createHttpError
 const createHttpError = {
@@ -26,7 +26,7 @@ function mockVerifyToken(token: string): {
 	iat: number
 	exp: number
 } {
-	return jwt.verify(token, JWT_SECRET) as any
+	return jwt.verify(token, JWT_SECRET_AUTH) as any
 }
 
 // Function to test
@@ -44,7 +44,7 @@ describe('Validate Admin Usecase', () => {
 		is_admin?: boolean
 		type: string
 	}): string {
-		return jwt.sign(payload, JWT_SECRET, { expiresIn: '1h' })
+		return jwt.sign(payload, JWT_SECRET_AUTH, { expiresIn: '1h' })
 	}
 
 	// ===========================================

--- a/services/auth/app/utils/jwt.test.ts
+++ b/services/auth/app/utils/jwt.test.ts
@@ -13,7 +13,7 @@ import { describe, test, expect, beforeAll } from '@jest/globals'
 import jwt from 'jsonwebtoken'
 
 // Mock du secret JWT pour les tests
-const JWT_SECRET = 'test-secret-key-for-jwt-testing'
+const JWT_SECRET_AUTH = 'test-secret-key-for-jwt-testing'
 
 // Fonctions à tester (réimplémentées pour éviter les dépendances)
 function signToken(
@@ -24,14 +24,14 @@ function signToken(
 		type: string
 	},
 	expiresIn: string,
-	secret: string = JWT_SECRET
+	secret: string = JWT_SECRET_AUTH
 ): string {
 	return jwt.sign(payload, secret, { expiresIn })
 }
 
 function verifyToken(
 	token: string,
-	secret: string = JWT_SECRET
+	secret: string = JWT_SECRET_AUTH
 ): {
 	user_id: number
 	login: string
@@ -106,7 +106,7 @@ describe('JWT Utils', () => {
 		const token = signToken(payload, '1h', 'different-secret')
 
 		expect(() => {
-			verifyToken(token, JWT_SECRET)
+			verifyToken(token, JWT_SECRET_AUTH)
 		}).toThrow()
 	})
 

--- a/services/auth/app/utils/jwt.ts
+++ b/services/auth/app/utils/jwt.ts
@@ -2,10 +2,6 @@ import jwt from 'jsonwebtoken'
 import ms from 'ms'
 import { env } from '../env/checkEnv.js'
 
-function getJWTSecret(): string {
-	return env.JWT_SECRET
-}
-
 export function signToken(
 	payload: {
 		user_id: number
@@ -15,7 +11,7 @@ export function signToken(
 	},
 	expiresIn: ms.StringValue
 ): string {
-	const secret = getJWTSecret()
+	const secret = env.JWT_SECRET_AUTH
 	return jwt.sign(payload, secret, { expiresIn: expiresIn })
 }
 
@@ -28,6 +24,6 @@ export interface JwtPayload {
 }
 
 export function verifyToken(token: string): JwtPayload {
-	const secret = getJWTSecret()
+	const secret = env.JWT_SECRET_AUTH
 	return jwt.verify(token, secret) as JwtPayload
 }

--- a/services/game/app/env/checkEnv.ts
+++ b/services/game/app/env/checkEnv.ts
@@ -5,14 +5,14 @@ const envSchema = z
 	.object({
 		DTO_OPENAPI_FILE: z.string().min(1),
 		PORT: z.coerce.number().min(1).max(65535),
-		JWT_SECRET: z.string().min(1),
+		JWT_SECRET_AUTH: z.string().min(1),
 		JWT_SECRET_GAME: z.string().min(1),
 		GAME_DB_PATH: z.string().min(1),
 		SWAGGER_HOST: z.string().min(1).default('http://localhost')
 	})
 	.transform((env) => ({
 		PORT: env.PORT,
-		JWT_SECRET: env.JWT_SECRET,
+		JWT_SECRET_AUTH: env.JWT_SECRET_AUTH,
 		JWT_SECRET_GAME: env.JWT_SECRET_GAME,
 		GAME_DB_PATH: env.GAME_DB_PATH,
 		openAPISchema: loadOpenAPISchema(env.DTO_OPENAPI_FILE),

--- a/services/game/app/index.ts
+++ b/services/game/app/index.ts
@@ -29,7 +29,7 @@ async function start(): Promise<void> {
 			transform: jsonSchemaTransform
 		},
 		{
-			main: env.JWT_SECRET,
+			main: env.JWT_SECRET_AUTH,
 			service: env.JWT_SECRET_GAME
 		}
 	)

--- a/services/social/app/env/checkEnv.ts
+++ b/services/social/app/env/checkEnv.ts
@@ -5,7 +5,7 @@ const envSchema = z
 	.object({
 		DTO_OPENAPI_FILE: z.string().min(1),
 		PORT: z.coerce.number().min(1).max(65535),
-		JWT_SECRET: z.string().min(1),
+		JWT_SECRET_AUTH: z.string().min(1),
 		JWT_SECRET_SOCIAL: z.string().min(1),
 		USERS_SERVICE_URL: z.string().min(1),
 		INTERNAL_API_SECRET: z.string().min(1),
@@ -14,7 +14,7 @@ const envSchema = z
 	})
 	.transform((env) => ({
 		PORT: env.PORT,
-		JWT_SECRET: env.JWT_SECRET,
+		JWT_SECRET_AUTH: env.JWT_SECRET_AUTH,
 		JWT_SECRET_SOCIAL: env.JWT_SECRET_SOCIAL,
 		USERS_SERVICE_URL: env.USERS_SERVICE_URL,
 		INTERNAL_API_SECRET: env.INTERNAL_API_SECRET,

--- a/services/social/app/index.ts
+++ b/services/social/app/index.ts
@@ -28,7 +28,7 @@ export async function start(): Promise<void> {
 			transform: jsonSchemaTransform
 		},
 		{
-			main: env.JWT_SECRET,
+			main: env.JWT_SECRET_AUTH,
 			service: env.JWT_SECRET_SOCIAL
 		}
 	)

--- a/services/users/app/env/checkEnv.ts
+++ b/services/users/app/env/checkEnv.ts
@@ -5,7 +5,7 @@ const envSchema = z
 	.object({
 		DTO_OPENAPI_FILE: z.string().min(1),
 		PORT: z.coerce.number().min(1).max(65535),
-		JWT_SECRET: z.string().min(1),
+		JWT_SECRET_AUTH: z.string().min(1),
 		AUTH_SERVICE_URL: z.string().min(1),
 		INTERNAL_API_SECRET: z.string().min(1),
 		USERS_DB_PATH: z.string().min(1),
@@ -13,7 +13,7 @@ const envSchema = z
 	})
 	.transform((env) => ({
 		PORT: env.PORT,
-		JWT_SECRET: env.JWT_SECRET,
+		JWT_SECRET_AUTH: env.JWT_SECRET_AUTH,
 		INTERNAL_API_SECRET: env.INTERNAL_API_SECRET,
 		AUTH_SERVICE_URL: env.AUTH_SERVICE_URL,
 		USERS_DB_PATH: env.USERS_DB_PATH,

--- a/services/users/app/index.ts
+++ b/services/users/app/index.ts
@@ -34,7 +34,7 @@ function createApp(): FastifyInstance {
 	app.register(fastifyCookie)
 
 	app.register(fastifyJwt, {
-		secret: env.JWT_SECRET,
+		secret: env.JWT_SECRET_AUTH,
 		cookie: {
 			cookieName: 'auth_token',
 			signed: false


### PR DESCRIPTION
This pull request standardizes the naming of JWT secrets across all services by replacing the environment variable `JWT_SECRET` with `JWT_SECRET_AUTH`, ensuring consistency and clarity for authentication-related secrets. It updates environment files, configuration schemas, source code, and tests to use the new variable name. Additionally, it removes unused admin token configuration from example and workflow files.

**JWT Secret Variable Standardization**

* Updated environment variable names from `JWT_SECRET` to `JWT_SECRET_AUTH` in `.env.example`, service environment schemas (`checkEnv.ts`), and workflow files to clarify its use for authentication purposes. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL120-R114) [[2]](diffhunk://#diff-3c8bd585018ad3b9fcd5c885e44329f1359535866e1cc30c1cc3b89bd801e688L84-R81) [[3]](diffhunk://#diff-70b6bf82dd9eeabc1d3bdf9104503c90b500b2b70f79bb673702312b41ad3cb9L8-R8) [[4]](diffhunk://#diff-7b6b8a8571fa7123990e79e60cc3b7dbc2fbe8a733e690483abc98b4f5423361L12-R12) [[5]](diffhunk://#diff-a80d28fb8891241c78a12f9e5f4359fa60f9ab3e611cd0717b6961c9b6e5a71aL8-R15) [[6]](diffhunk://#diff-65535d2e4430dc17192615e529a5ce2fe3110976ca2f7df87b9c7063524037b4L8-R8) [[7]](diffhunk://#diff-72a86f37523030737d05402083d121c8bfe1dfe5d5cdd5891dc1635fb3286ec3L8-R16)
* Refactored all usages in service initialization and JWT registration to use `JWT_SECRET_AUTH` instead of `JWT_SECRET` in source files (`index.ts`). [[1]](diffhunk://#diff-4ea409f4fa6d157669ce167afad06d4aaf5eda5976a9143015bea17dc9ca052eL25-R25) [[2]](diffhunk://#diff-c076e2cb34073711185986fff46a7816bccc053b024a083297dd0ee88aba0adeL27-R27) [[3]](diffhunk://#diff-f617a7368019697d2fe56cbaa5311dfe40c908a7722b56bf089ab6790e5421a4L32-R32) [[4]](diffhunk://#diff-4d4adc861fc270bb75bb7be0f0162351c1dca5757a5aa5c55e27fa8699e35d6bL31-R31) [[5]](diffhunk://#diff-ff583aa21a61ce5186d7cdba5d3773a1ba8700de58ab3c5d46d89df8c7e6d4b5L37-R37)

**Configuration Schema and Transformation Updates**

* Modified transformation logic in environment schema files to use `JWT_SECRET_AUTH`, ensuring correct variable propagation throughout the codebase. [[1]](diffhunk://#diff-70b6bf82dd9eeabc1d3bdf9104503c90b500b2b70f79bb673702312b41ad3cb9L21-R21) [[2]](diffhunk://#diff-7b6b8a8571fa7123990e79e60cc3b7dbc2fbe8a733e690483abc98b4f5423361L25-R25) [[3]](diffhunk://#diff-a80d28fb8891241c78a12f9e5f4359fa60f9ab3e611cd0717b6961c9b6e5a71aL8-R15) [[4]](diffhunk://#diff-65535d2e4430dc17192615e529a5ce2fe3110976ca2f7df87b9c7063524037b4L17-R17) [[5]](diffhunk://#diff-72a86f37523030737d05402083d121c8bfe1dfe5d5cdd5891dc1635fb3286ec3L8-R16)

**Source Code Refactoring**

* Updated utility functions and JWT handling logic in `jwt.ts` and related files to reference `JWT_SECRET_AUTH`. Removed redundant secret getter functions for simplification. [[1]](diffhunk://#diff-986bcb08f26c83aa24e2486e8a39f98398a147c0f511bbbbaed4d18a9fa48f6dL5-L8) [[2]](diffhunk://#diff-986bcb08f26c83aa24e2486e8a39f98398a147c0f511bbbbaed4d18a9fa48f6dL18-R14) [[3]](diffhunk://#diff-986bcb08f26c83aa24e2486e8a39f98398a147c0f511bbbbaed4d18a9fa48f6dL31-R27)

**Test Updates**

* Refactored all test files to use `JWT_SECRET_AUTH` for signing and verifying tokens, ensuring alignment with the new environment variable naming. [[1]](diffhunk://#diff-17f4181121a04c7d0f655368803ebfd008d357a0606485a93b981362434ecb0bL14-R14) [[2]](diffhunk://#diff-17f4181121a04c7d0f655368803ebfd008d357a0606485a93b981362434ecb0bL29-R29) [[3]](diffhunk://#diff-17f4181121a04c7d0f655368803ebfd008d357a0606485a93b981362434ecb0bL47-R47) [[4]](diffhunk://#diff-8458c62d5c5bd32f25b39e870469c7a1c2c299c481be71964829f9977fdd9731L16-R16) [[5]](diffhunk://#diff-8458c62d5c5bd32f25b39e870469c7a1c2c299c481be71964829f9977fdd9731L27-R34) [[6]](diffhunk://#diff-8458c62d5c5bd32f25b39e870469c7a1c2c299c481be71964829f9977fdd9731L109-R109)

**Cleanup of Unused Admin Token Configuration**

* Removed unused `ADMIN_TOKEN` environment variable from `.env.example` and workflow files to reduce confusion and clutter. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL85-L90) [[2]](diffhunk://#diff-3c8bd585018ad3b9fcd5c885e44329f1359535866e1cc30c1cc3b89bd801e688L68-L70)