### PR TITLE
fix: update cookie maxAge to extend session duration and clear game s…

### DIFF
--- a/services/auth/app/controllers/2faController.ts
+++ b/services/auth/app/controllers/2faController.ts
@@ -84,7 +84,7 @@ export async function verify2faLoginController(
 		sameSite: 'strict',
 		secure: true,
 		path: '/',
-		maxAge: 60 * 15
+		maxAge: 60 * 60 * 4
 	})
 	reply.clearCookie('twofa_token', { path: '/' })
 	return reply.code(200).send(result)

--- a/services/auth/app/controllers/authController.ts
+++ b/services/auth/app/controllers/authController.ts
@@ -28,7 +28,7 @@ export async function registerController(
 		sameSite: 'strict',
 		secure: true,
 		path: '/',
-		maxAge: 60 * 60
+		maxAge: 60 * 60 * 4
 	})
 	reply.code(201)
 	return { message: 'User registered successfully', token }
@@ -60,7 +60,7 @@ export async function loginController(
 			sameSite: 'strict',
 			secure: true,
 			path: '/',
-			maxAge: 60 * 60
+			maxAge: 60 * 60 * 4
 		})
 		return {
 			pre_2fa_required: false,

--- a/services/auth/app/controllers/oauthController.ts
+++ b/services/auth/app/controllers/oauthController.ts
@@ -1,7 +1,6 @@
 import type { FastifyReply, FastifyRequest } from 'fastify'
 import { LoginResponseDTO } from '@ft_transcendence/common'
 import { googleLoginUsecase } from '../usecases/oauthUsecases.js'
-import { env } from '../env/checkEnv.js'
 
 export async function googleLoginController(
 	request: FastifyRequest,
@@ -26,7 +25,7 @@ export async function googleLoginController(
 			sameSite: 'strict',
 			secure: true,
 			path: '/',
-			maxAge: 60 * 60
+			maxAge: 60 * 60 * 4
 		})
 		return {
 			pre_2fa_required: false,

--- a/services/frontend/app/src/game/network/initGameWS.ts
+++ b/services/frontend/app/src/game/network/initGameWS.ts
@@ -26,6 +26,7 @@ export function initGameWS(backTo: string) {
 				}
 			})
 			.catch((error: any) => {
+				gameStore.clear()
 				notyf.open({
 					type: ToastActionType.ERROR_ACTION,
 					message: 'Connection to game server failed'

--- a/services/frontend/app/src/game/tournament/tournamentMatchJoin.ts
+++ b/services/frontend/app/src/game/tournament/tournamentMatchJoin.ts
@@ -62,7 +62,6 @@ export async function checkAndJoinUserMatches(
 	onStopPolling: () => void
 ): Promise<void> {
 	if (!['completed', 'ongoing'].includes(tournament.status)) return
-	if (gameStore.gameCode) return
 
 	const match = findPendingUserMatch(tournament)
 	if (!match?.gameCode) return


### PR DESCRIPTION
This pull request primarily extends the authentication session lifetimes and introduces a minor bug fix for the game frontend. The most significant changes are grouped below by theme.

**Authentication Session Lifetime Increases:**

* Increased the `maxAge` (session duration) for authentication cookies from 1 hour to 4 hours in the following controllers: `registerController`, `loginController`, `verify2faLoginController`, and `googleLoginController` (`authController.ts`, `2faController.ts`, `oauthController.ts`). 

**Frontend Game Bug Fixes and Improvements:**

* Added a call to `gameStore.clear()` when a connection to the game server fails, ensuring stale game state is cleared (`initGameWS.ts`).
* Removed an unnecessary check for `gameStore.gameCode` in `checkAndJoinUserMatches`, allowing users to join matches even if a game code is already present (`tournamentMatchJoin.ts`).

**Code Cleanup:**

* Removed an unused import of `env` from `oauthController.ts`.…tore on connection failure